### PR TITLE
Inherit line-height within the f-placeholder mixin

### DIFF
--- a/vendor/assets/stylesheets/fundly-style-guide/components/_forms.scss
+++ b/vendor/assets/stylesheets/fundly-style-guide/components/_forms.scss
@@ -2,7 +2,7 @@
 @mixin f-placeholder {
   padding: inherit 0;
   font-style: italic;
-  line-height: 1.5em;
+  line-height: inherit;
 }
 
 label {


### PR DESCRIPTION
Yo James, inheriting line-height gives more flexiblity i.e. in the case of applying
.f-button to a input to make it look like a button.
