### PR TITLE
Add line-height hack for .f-button in the .f-input-decorator

### DIFF
--- a/vendor/assets/stylesheets/fundly-style-guide/components/_buttons.scss
+++ b/vendor/assets/stylesheets/fundly-style-guide/components/_buttons.scss
@@ -91,7 +91,7 @@
   }
 
   &.facebook, &.twitter, &.google, &.linkedin,
-  &.pinterest, &.email, &.youtube {
+  &.pinterest, &.email, &.youtube, &.whats-app {
     &:before {
       font: {
         family: FontAwesome;
@@ -152,6 +152,14 @@
   &.email {
     &:before {
       content: $fa-var-envelope;
+    }
+  }
+  &.whats-app {
+    background-color: $f-color-whats-app;
+    color: $f-color-white;
+    &:before {
+      font-family: FundlyIcons;
+      content: "\e612";
     }
   }
 }

--- a/vendor/assets/stylesheets/fundly-style-guide/core/_variables.scss
+++ b/vendor/assets/stylesheets/fundly-style-guide/core/_variables.scss
@@ -86,6 +86,7 @@ $f-color-twitter:      #1ba5e2 !default;
 $f-color-google:       #ff0000 !default;
 $f-color-linkedin:     #1d87bd !default;
 $f-color-pinterest:    #cb2027 !default;
+$f-color-whats-app:    #60B82D !default;
 
 // Primary color
 $f-color-primary:      #FF8B5D !default;


### PR DESCRIPTION
Not sure why this works, but this fixes the issue on Chrome Desktop/Mobile and Mobile Safari. (Interestingly, this doesn't fix it on FF but I guess that doesn't matter since it's on mobile...) I attached a pic of the issue without the hack. Also, this only happens when applied the .f-fs-large to the .f-input-decorator class. Any thoughts on this issue? Even I'm not sure what this hack is really doing... haha

Original HAML code:

```
       .f-input-decorator.f-fs-large
          %input.js-personal{name: 'name', type: 'text', placeholder: 'First & Last Name', value: current_user.try(:fullname), autocapitalize: 'words'}
          .f-decorator.none
            %button.js-facebook.f-button.facebook
```

![raise_money_](https://f.cloud.github.com/assets/595757/2403325/64825fac-aa2d-11e3-9fa1-05ece11f36f0.jpg)
![raise_money_](https://f.cloud.github.com/assets/595757/2403307/3029eee6-aa2d-11e3-9fb5-6c12128e9432.jpg)
![raise_money_](https://f.cloud.github.com/assets/595757/2403316/479658a8-aa2d-11e3-989b-422b9d277647.jpg)
