### PR TITLE
Added WhatsApp social button

### DIFF
--- a/vendor/assets/stylesheets/fundly-style-guide/components/_buttons.scss
+++ b/vendor/assets/stylesheets/fundly-style-guide/components/_buttons.scss
@@ -91,7 +91,7 @@
   }
 
   &.facebook, &.twitter, &.google, &.linkedin,
-  &.pinterest, &.email, &.youtube {
+  &.pinterest, &.email, &.youtube, &.whats-app {
     &:before {
       font: {
         family: FontAwesome;
@@ -148,6 +148,14 @@
   &.email {
     &:before {
       content: $fa-var-envelope;
+    }
+  }
+  &.whats-app {
+    background-color: $f-color-whats-app;
+    color: $f-color-white;
+    &:before {
+      font-family: FundlyIcons;
+      content: "\e612";
     }
   }
 }

--- a/vendor/assets/stylesheets/fundly-style-guide/core/_variables.scss
+++ b/vendor/assets/stylesheets/fundly-style-guide/core/_variables.scss
@@ -86,6 +86,7 @@ $f-color-twitter:      #1ba5e2 !default;
 $f-color-google:       #ff0000 !default;
 $f-color-linkedin:     #1d87bd !default;
 $f-color-pinterest:    #cb2027 !default;
+$f-color-whats-app:    #60B82D !default;
 
 // Primary color
 $f-color-primary:      #FF8B5D !default;


### PR DESCRIPTION
James right now I'm hard coding the content character of the what's app icon into the .f-button.whats-app selector. Seems kind of dirty since we're generating the font in the other repo, not sure what's the best thing to do. 

Note: For now, I'm hardcoding some whatsapp CSS in the main fundly app until we get this merged.

https://github.com/fundly/fundly-icon-font/pull/1
