### PR TITLE
Add line-height hack for .f-button in the .f-input-decorator

### DIFF
--- a/vendor/assets/stylesheets/fundly-style-guide/components/_buttons.scss
+++ b/vendor/assets/stylesheets/fundly-style-guide/components/_buttons.scss
@@ -98,6 +98,10 @@
         size: 1.20em;
       }
       margin-right: 0.5em;
+      // Setting the line-height fixes a Chrome issue when it's being wrapped
+      // within the .f-decorator class. Without the line-height, it
+      // adds a pixel to the height of the button
+      line-height: normal;
     }
     &:empty:before {
       margin-right: 0;


### PR DESCRIPTION
**Note**: This is a proper PR of the original PR https://github.com/fundly/style-guide/pull/5

Not sure why this works, but this fixes the issue on Chrome Desktop/Mobile and Mobile Safari. (Interestingly, this doesn't fix it on FF but I guess that doesn't matter since it's on mobile...) I attached a pic of the issue without the hack. Also, this only happens when applied the .f-fs-large to the .f-input-decorator class. Any thoughts on this issue? Even I'm not sure what this hack is really doing... haha

Original HAML code:

```
       .f-input-decorator.f-fs-large
          %input.js-personal{name: 'name', type: 'text', placeholder: 'First & Last Name', value: current_user.try(:fullname), autocapitalize: 'words'}
          .f-decorator.none
            %button.js-facebook.f-button.facebook
```

![raise_money_](https://f.cloud.github.com/assets/595757/2403325/64825fac-aa2d-11e3-9fa1-05ece11f36f0.jpg)
![raise_money_](https://f.cloud.github.com/assets/595757/2403307/3029eee6-aa2d-11e3-9fb5-6c12128e9432.jpg)
![raise_money_](https://f.cloud.github.com/assets/595757/2403316/479658a8-aa2d-11e3-989b-422b9d277647.jpg)
